### PR TITLE
add an encodeURIComponent stack message

### DIFF
--- a/src/exceptionHandler.ts
+++ b/src/exceptionHandler.ts
@@ -16,6 +16,7 @@ export default function setupExceptionHandler() {
           priority: 1,
           message: error.message,
           stack: error.stack,
+          uriEncodedStackTrace: encodeURIComponent(error.stack || ''),
         });
       } else {
         recordError(`Fatal JS error: ${error}`);


### PR DESCRIPTION
This MR adds a new param `resolvedStackTraceLink` to the list of key/values to log when there is a JS crash. This will allow easier exploitation of the stack trace in an external explorer.